### PR TITLE
Ensure Twilio SMS table installs on upgrade

### DIFF
--- a/arm-repair-estimates.php
+++ b/arm-repair-estimates.php
@@ -44,6 +44,7 @@ add_action('plugins_loaded', function () {
 
     ARM\Integrations\Payments_Stripe::boot();
     ARM\Integrations\Payments_PayPal::boot();
+    ARM\Integrations\Twilio::boot();
     ARM\Integrations\PartsTech::boot();
     ARM\Integrations\Zoho::boot();
 

--- a/includes/install/class-activator.php
+++ b/includes/install/class-activator.php
@@ -16,7 +16,7 @@ final class Activator {
         // Make sure dbDelta is available.
         require_once ABSPATH . 'wp-admin/includes/upgrade.php';
 
-        // If constants/files aren’t available yet (defensive), define/require them.
+        // If constants/files arenâ€™t available yet (defensive), define/require them.
         if (!defined('ARM_RE_PATH')) {
             define('ARM_RE_PATH', plugin_dir_path(dirname(__FILE__, 2)));
         }
@@ -163,6 +163,7 @@ final class Activator {
         if (class_exists('\\ARM\\Bundles\\Controller'))   \ARM\Bundles\Controller::install_tables();
         if (class_exists('\\ARM\\Integrations\\Payments_Stripe'))  \ARM\Integrations\Payments_Stripe::install_tables();
         if (class_exists('\\ARM\\Integrations\\Payments_PayPal'))    \ARM\Integrations\Payments_PayPal::install_tables();
+        if (class_exists('\\ARM\\Integrations\\Twilio'))            \ARM\Integrations\Twilio::install_tables();
 
     }
 
@@ -177,6 +178,7 @@ final class Activator {
             '\\ARM\\PDF\\Controller'       => 'includes/pdf/Controller.php',
             '\\ARM\\Integrations\\Payments_Stripe'  => 'includes/integrations/Payments_Stripe.php',
             '\\ARM\\Integrations\\Payments_PayPal'    => 'includes/integrations/Payments_PayPal.php',
+            '\\ARM\\Integrations\\Twilio'            => 'includes/integrations/Twilio.php',
         ];
         foreach ($map as $class => $rel) {
             if (!class_exists($class) && file_exists(ARM_RE_PATH . $rel)) {

--- a/includes/integrations/Twilio.php
+++ b/includes/integrations/Twilio.php
@@ -1,0 +1,65 @@
+<?php
+namespace ARM\Integrations;
+
+if (!defined('ABSPATH')) exit;
+
+class Twilio {
+    public static function boot(): void {
+        global $wpdb;
+        if (!isset($wpdb->prefix)) {
+            return;
+        }
+
+        $table = $wpdb->prefix . 'arm_sms_messages';
+        $schema = $wpdb->dbname ?? (defined('DB_NAME') ? DB_NAME : null);
+
+        if (!$schema) {
+            return;
+        }
+
+        $exists = $wpdb->get_var(
+            $wpdb->prepare(
+                'SELECT TABLE_NAME FROM information_schema.TABLES WHERE TABLE_SCHEMA = %s AND TABLE_NAME = %s',
+                $schema,
+                $table
+            )
+        );
+
+        if ($exists !== $table) {
+            self::install_tables();
+        }
+    }
+
+    public static function install_tables(): void {
+        global $wpdb;
+        if (!function_exists('maybe_create_table')) {
+            require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+        }
+
+        $table   = $wpdb->prefix . 'arm_sms_messages';
+        $charset = $wpdb->get_charset_collate();
+
+        $sql = "CREATE TABLE $table (
+            id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+            message_sid VARCHAR(191) NULL,
+            related_type VARCHAR(32) NULL,
+            related_id BIGINT UNSIGNED NULL,
+            direction ENUM('outbound','inbound') NOT NULL DEFAULT 'outbound',
+            to_number VARCHAR(32) NULL,
+            from_number VARCHAR(32) NULL,
+            body TEXT NULL,
+            status VARCHAR(32) NULL,
+            error_code VARCHAR(32) NULL,
+            error_message TEXT NULL,
+            payload LONGTEXT NULL,
+            created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            updated_at DATETIME NULL,
+            PRIMARY KEY  (id),
+            KEY message_sid (message_sid),
+            KEY related (related_type, related_id),
+            KEY created_at (created_at)
+        ) $charset;";
+
+        maybe_create_table($table, $sql);
+    }
+}


### PR DESCRIPTION
## Summary
- add a Twilio integration bootstrap that checks for the SMS log table and installs it as needed using `maybe_create_table`
- register the Twilio installer with the plugin activator and boot sequence so new and upgraded sites both provision the table
- harden the Twilio bootstrap by querying `information_schema` for the table and only loading the upgrader helpers when needed

## Testing
- php -l includes/integrations/Twilio.php

------
https://chatgpt.com/codex/tasks/task_e_68dc831f91f8832c83c5acd710891845