### PR TITLE
Add vehicle linkage workflow to estimates and invoices

### DIFF
--- a/includes/invoices/PublicView.php
+++ b/includes/invoices/PublicView.php
@@ -22,6 +22,22 @@ class PublicView {
         echo '<div class="arm-invoice-view">';
         echo '<h1>'.esc_html(sprintf(__('Invoice %s','arm-repair-estimates'), $inv->invoice_no)).'</h1>';
         echo '<p><strong>'.esc_html($cust->first_name.' '.$cust->last_name).'</strong> &lt;'.esc_html($cust->email).'&gt;</p>';
+        $vehicle_parts = array_filter([
+            $inv->vehicle_year ?? '',
+            $inv->vehicle_make ?? '',
+            $inv->vehicle_model ?? '',
+            $inv->vehicle_engine ?? '',
+            $inv->vehicle_trim ?? '',
+        ], function($part){ return $part !== null && $part !== ''; });
+        $vehicle_summary = trim(implode(' ', $vehicle_parts));
+        if ($vehicle_summary || !empty($inv->vehicle_plate) || !empty($inv->vehicle_vin) || !empty($inv->vehicle_mileage)) {
+            echo '<p><strong>'.esc_html__('Vehicle','arm-repair-estimates').'</strong><br>';
+            if ($vehicle_summary) { echo esc_html($vehicle_summary).'<br>'; }
+            if (!empty($inv->vehicle_plate)) { echo esc_html__('License Plate','arm-repair-estimates').': '.esc_html($inv->vehicle_plate).'<br>'; }
+            if (!empty($inv->vehicle_vin)) { echo esc_html__('VIN','arm-repair-estimates').': '.esc_html($inv->vehicle_vin).'<br>'; }
+            if (!empty($inv->vehicle_mileage)) { echo esc_html__('Mileage','arm-repair-estimates').': '.esc_html($inv->vehicle_mileage).'<br>'; }
+            echo '</p>';
+        }
         echo '<table class="widefat"><thead><tr><th>'.__('Type').'</th><th>'.__('Description').'</th><th>'.__('Qty').'</th><th>'.__('Unit').'</th><th>'.__('Total').'</th></tr></thead><tbody>';
         foreach ($items as $it) {
             echo '<tr><td>'.esc_html($it->item_type).'</td><td>'.esc_html($it->description).'</td><td>'.esc_html($it->qty).'</td><td>'.esc_html(number_format((float)$it->unit_price,2)).'</td><td>'.esc_html(number_format((float)$it->line_total,2)).'</td></tr>';

--- a/templates/estimate-view.php
+++ b/templates/estimate-view.php
@@ -57,6 +57,25 @@ $can_act = in_array($est->status, ['SENT','NEEDS_REAPPROVAL'], true);
           <div><strong><?php _e('Expires', 'arm-repair-estimates'); ?>:</strong> <?php echo esc_html($est->expires_at); ?></div>
         <?php endif; ?>
         <div><strong><?php _e('Created', 'arm-repair-estimates'); ?>:</strong> <?php echo esc_html($est->created_at); ?></div>
+        <?php
+          $vehicle_parts = array_filter([
+              $est->vehicle_year ?? '',
+              $est->vehicle_make ?? '',
+              $est->vehicle_model ?? '',
+              $est->vehicle_engine ?? '',
+              $est->vehicle_trim ?? '',
+          ], function($part){ return $part !== null && $part !== ''; });
+          $vehicle_summary = trim(implode(' ', $vehicle_parts));
+        ?>
+        <?php if ($vehicle_summary || !empty($est->vehicle_vin) || !empty($est->vehicle_plate) || !empty($est->vehicle_mileage)): ?>
+          <div style="margin-top:8px;">
+            <strong><?php _e('Vehicle','arm-repair-estimates'); ?>:</strong>
+            <?php if ($vehicle_summary): ?><div><?php echo esc_html($vehicle_summary); ?></div><?php endif; ?>
+            <?php if (!empty($est->vehicle_plate)): ?><div><?php _e('License Plate','arm-repair-estimates'); ?>: <?php echo esc_html($est->vehicle_plate); ?></div><?php endif; ?>
+            <?php if (!empty($est->vehicle_vin)): ?><div><?php _e('VIN','arm-repair-estimates'); ?>: <?php echo esc_html($est->vehicle_vin); ?></div><?php endif; ?>
+            <?php if (!empty($est->vehicle_mileage)): ?><div><?php _e('Mileage','arm-repair-estimates'); ?>: <?php echo esc_html($est->vehicle_mileage); ?></div><?php endif; ?>
+          </div>
+        <?php endif; ?>
       </div>
     </div>
 

--- a/templates/invoice-view.php
+++ b/templates/invoice-view.php
@@ -52,6 +52,25 @@ $currency          = strtoupper(get_option('arm_re_currency','usd'));
       <?php if (!empty($cust->city) || !empty($cust->zip)): ?><div><?php echo esc_html(trim("{$cust->city} {$cust->zip}")); ?></div><?php endif; ?>
       <?php if (!empty($cust->phone)): ?><div><?php echo esc_html($cust->phone); ?></div><?php endif; ?>
       <?php if (!empty($cust->email)): ?><div><?php echo esc_html($cust->email); ?></div><?php endif; ?>
+      <?php
+        $invoice_vehicle_parts = array_filter([
+            $inv->vehicle_year ?? '',
+            $inv->vehicle_make ?? '',
+            $inv->vehicle_model ?? '',
+            $inv->vehicle_engine ?? '',
+            $inv->vehicle_trim ?? '',
+        ], function($part){ return $part !== null && $part !== ''; });
+        $invoice_vehicle_summary = trim(implode(' ', $invoice_vehicle_parts));
+      ?>
+      <?php if ($invoice_vehicle_summary || !empty($inv->vehicle_plate) || !empty($inv->vehicle_vin) || !empty($inv->vehicle_mileage)): ?>
+        <div style="margin-top:8px;">
+          <strong><?php _e('Vehicle','arm-repair-estimates'); ?>:</strong>
+          <?php if ($invoice_vehicle_summary): ?><div><?php echo esc_html($invoice_vehicle_summary); ?></div><?php endif; ?>
+          <?php if (!empty($inv->vehicle_plate)): ?><div><?php _e('License Plate','arm-repair-estimates'); ?>: <?php echo esc_html($inv->vehicle_plate); ?></div><?php endif; ?>
+          <?php if (!empty($inv->vehicle_vin)): ?><div><?php _e('VIN','arm-repair-estimates'); ?>: <?php echo esc_html($inv->vehicle_vin); ?></div><?php endif; ?>
+          <?php if (!empty($inv->vehicle_mileage)): ?><div><?php _e('Mileage','arm-repair-estimates'); ?>: <?php echo esc_html($inv->vehicle_mileage); ?></div><?php endif; ?>
+        </div>
+      <?php endif; ?>
     </div>
     <div style="text-align:right;display:flex;flex-direction:column;gap:10px;align-items:flex-end;">
       <a class="button" href="<?php echo esc_url($pdf_url); ?>"><?php _e('Download PDF','arm-repair-estimates'); ?></a>


### PR DESCRIPTION
## Summary
- add schema upgrades and install-time columns for vehicle metadata on estimates and invoices
- enhance the estimate form with vehicle selection, inline creation, and AJAX loading
- persist selected vehicle data through estimate saving, invoice conversion, and public templates

## Testing
- php -l includes/estimates/Controller.php
- php -l includes/invoices/Controller.php
- php -l includes/invoices/PublicView.php
- php -l templates/estimate-view.php
- php -l templates/invoice-view.php

------
https://chatgpt.com/codex/tasks/task_e_68dc37e4f590832ca4a4eb78b9f5e478