### PR TITLE
Add admin dashboard KPIs for inventory, warranty, and SMS

### DIFF
--- a/includes/admin/Dashboard.php
+++ b/includes/admin/Dashboard.php
@@ -1,154 +1,220 @@
 <?php
 namespace ARM\Admin;
 
-class Dashboard {
-    public static function boot() {
-        add_submenu_page(
-            'arm-repair-estimates',
-            __('Dashboard','arm-repair-estimates'),
-            __('Dashboard','arm-repair-estimates'),
-            'manage_options',
-            'arm-dashboard',
-            [__CLASS__,'render_dashboard']
-        );
-add_action('admin_enqueue_scripts', [__CLASS__, 'assets']);
+if (!defined('ABSPATH')) exit;
 
+require_once __DIR__ . '/DashboardMetrics.php';
+
+final class Dashboard
+{
+    public static function boot(): void
+    {
+        add_action('admin_menu', [__CLASS__, 'menu']);
+        add_action('admin_enqueue_scripts', [__CLASS__, 'assets']);
     }
 
-	public static function assets($hook) {
-	    if (strpos($hook,'arm-dashboard')===false) return;
-	    wp_enqueue_script('chart-js','https://cdn.jsdelivr.net/npm/chart.js',[],null,true);
-	}
+    public static function menu(): void
+    {
+        add_submenu_page(
+            'arm-repair-estimates',
+            __('Dashboard', 'arm-repair-estimates'),
+            __('Dashboard', 'arm-repair-estimates'),
+            'manage_options',
+            'arm-dashboard',
+            [__CLASS__, 'render_dashboard']
+        );
+    }
 
-
-    public static function render_dashboard() {
-        if (!current_user_can('manage_options')) return;
-        global $wpdb;
-        $eT=$wpdb->prefix.'arm_estimates';
-        $iT=$wpdb->prefix.'arm_invoices';
-
-        // Estimates
-        $est_pending=$wpdb->get_var("SELECT COUNT(*) FROM $eT WHERE status='PENDING'");
-        $est_accepted=$wpdb->get_var("SELECT COUNT(*) FROM $eT WHERE status='APPROVED'");
-        $est_rejected=$wpdb->get_var("SELECT COUNT(*) FROM $eT WHERE status='REJECTED'");
-
-        // Invoices
-        $inv_total=$wpdb->get_var("SELECT COUNT(*) FROM $iT");
-        $inv_paid=$wpdb->get_var("SELECT COUNT(*) FROM $iT WHERE status='PAID'");
-        $inv_unpaid=$wpdb->get_var("SELECT COUNT(*) FROM $iT WHERE status='UNPAID'");
-        $inv_void=$wpdb->get_var("SELECT COUNT(*) FROM $iT WHERE status='VOID'");
-
-        $avg_invoice=$wpdb->get_var("SELECT AVG(total) FROM $iT WHERE status='PAID'");
-        $total_paid=$wpdb->get_var("SELECT SUM(total) FROM $iT WHERE status='PAID'");
-        $total_unpaid=$wpdb->get_var("SELECT SUM(total) FROM $iT WHERE status='UNPAID'");
-        $total_tax=$wpdb->get_var("SELECT SUM(tax_amount) FROM $iT WHERE status='PAID'");
-
-// Monthly invoice totals (last 6 months)
-$rows=$wpdb->get_results("
-    SELECT DATE_FORMAT(created_at,'%Y-%m') AS ym, SUM(total) as total
-    FROM $iT WHERE status='PAID'
-    GROUP BY ym ORDER BY ym DESC LIMIT 6
-");
-$months=[]; $totals=[];
-foreach (array_reverse($rows) as $r) {
-    $months[]=$r->ym;
-    $totals[]=(float)$r->total;
-}
-
-// Estimate approvals vs rejections (last 6 months)
-$rows=$wpdb->get_results("
-    SELECT DATE_FORMAT(created_at,'%Y-%m') as ym,
-    SUM(CASE WHEN status='APPROVED' THEN 1 ELSE 0 END) as approved,
-    SUM(CASE WHEN status='REJECTED' THEN 1 ELSE 0 END) as rejected
-    FROM $eT GROUP BY ym ORDER BY ym DESC LIMIT 6
-");
-$est_months=[]; $approved=[]; $rejected=[];
-foreach (array_reverse($rows) as $r) {
-    $est_months[]=$r->ym;
-    $approved[]=(int)$r->approved;
-    $rejected[]=(int)$r->rejected;
-}
-
-
-        ?>
-<h2><?php _e('Trends','arm-repair-estimates'); ?></h2>
-<div style="max-width:800px;">
-  <canvas id="arm_invoice_chart"></canvas>
-</div>
-<div style="max-width:800px;margin-top:2em;">
-  <canvas id="arm_estimate_chart"></canvas>
-</div>
-<script>
-document.addEventListener('DOMContentLoaded', function(){
-  const ctx1=document.getElementById('arm_invoice_chart').getContext('2d');
-  new Chart(ctx1,{
-    type:'bar',
-    data:{
-      labels: <?php echo json_encode($months); ?>,
-      datasets:[{
-        label:'Invoice Totals',
-        data: <?php echo json_encode($totals); ?>,
-        backgroundColor:'rgba(75, 192, 192, 0.6)'
-      }]
-    },
-    options:{scales:{y:{beginAtZero:true}}}
-  });
-
-  const ctx2=document.getElementById('arm_estimate_chart').getContext('2d');
-  new Chart(ctx2,{
-    type:'line',
-    data:{
-      labels: <?php echo json_encode($est_months); ?>,
-      datasets:[
-        {
-          label:'Approved',
-          data: <?php echo json_encode($approved); ?>,
-          borderColor:'rgba(54, 162, 235, 1)',
-          fill:false
-        },
-        {
-          label:'Rejected',
-          data: <?php echo json_encode($rejected); ?>,
-          borderColor:'rgba(255, 99, 132, 1)',
-          fill:false
+    public static function assets(string $hook): void
+    {
+        if (strpos($hook, 'arm-dashboard') === false) {
+            return;
         }
-      ]
-    },
-    options:{scales:{y:{beginAtZero:true}}}
-  });
-});
-</script>
+        wp_enqueue_script('chart-js', 'https://cdn.jsdelivr.net/npm/chart.js', [], null, true);
+    }
 
+    public static function render_dashboard(): void
+    {
+        if (!current_user_can('manage_options')) {
+            return;
+        }
+
+        global $wpdb;
+
+        $estimates = DashboardMetrics::estimate_counts($wpdb);
+        $invoices  = DashboardMetrics::invoice_counts($wpdb);
+        $inventory = DashboardMetrics::inventory_value($wpdb);
+        $warranty  = DashboardMetrics::warranty_claim_counts($wpdb);
+        $sms       = DashboardMetrics::sms_totals($wpdb);
+
+        $invoiceSeries  = DashboardMetrics::invoice_monthly_totals($wpdb);
+        $estimateSeries = DashboardMetrics::estimate_trends($wpdb);
+
+        $smsLabels = [];
+        $smsSent = [];
+        $smsDelivered = [];
+        $smsFailed = [];
+        foreach ($sms['channels'] as $channel => $counts) {
+            $smsLabels[]    = $channel;
+            $smsSent[]      = (int) $counts['sent'];
+            $smsDelivered[] = (int) $counts['delivered'];
+            $smsFailed[]    = (int) $counts['failed'];
+        }
+
+        $currencyValue = number_format_i18n((float) $inventory['value'], 2);
+        ?>
         <div class="wrap">
-          <h1><?php _e('Repair Shop Dashboard','arm-repair-estimates'); ?></h1>
-          
-          <h2><?php _e('Estimates','arm-repair-estimates'); ?></h2>
-          <ul class="arm-stats">
-            <li><?php echo esc_html($est_pending); ?> Pending</li>
-            <li><?php echo esc_html($est_accepted); ?> Approved</li>
-            <li><?php echo esc_html($est_rejected); ?> Rejected</li>
-          </ul>
+            <h1><?php esc_html_e('Repair Shop Dashboard', 'arm-repair-estimates'); ?></h1>
 
-          <h2><?php _e('Invoices','arm-repair-estimates'); ?></h2>
-          <ul class="arm-stats">
-            <li>Total: <?php echo esc_html($inv_total); ?></li>
-            <li>Paid: <?php echo esc_html($inv_paid); ?></li>
-            <li>Unpaid: <?php echo esc_html($inv_unpaid); ?></li>
-            <li>Voided: <?php echo esc_html($inv_void); ?></li>
-            <li>Average Paid Invoice: <?php echo esc_html(number_format((float)$avg_invoice,2)); ?></li>
-            <li>Total Paid: <?php echo esc_html(number_format((float)$total_paid,2)); ?></li>
-            <li>Total Unpaid: <?php echo esc_html(number_format((float)$total_unpaid,2)); ?></li>
-            <li>Total Sales Tax: <?php echo esc_html(number_format((float)$total_tax,2)); ?></li>
-          </ul>
+            <h2><?php esc_html_e('Estimates', 'arm-repair-estimates'); ?></h2>
+            <ul class="arm-stats">
+                <li><?php echo esc_html((int) $estimates['pending']); ?> <?php esc_html_e('Pending', 'arm-repair-estimates'); ?></li>
+                <li><?php echo esc_html((int) $estimates['approved']); ?> <?php esc_html_e('Approved', 'arm-repair-estimates'); ?></li>
+                <li><?php echo esc_html((int) $estimates['rejected']); ?> <?php esc_html_e('Rejected', 'arm-repair-estimates'); ?></li>
+            </ul>
 
-          <h2><?php _e('Quick Links','arm-repair-estimates'); ?></h2>
-          <p>
-            <a class="button" href="<?php echo admin_url('admin.php?page=arm-repair-estimates'); ?>">Estimates</a>
-            <a class="button" href="<?php echo admin_url('admin.php?page=arm-repair-invoices'); ?>">Invoices</a>
-            <a class="button" href="<?php echo admin_url('admin.php?page=arm-appointments'); ?>">Appointments</a>
-            <a class="button" href="<?php echo admin_url('admin.php?page=arm-dashboard'); ?>">Dashboard</a>
-          </p>
+            <h2><?php esc_html_e('Invoices', 'arm-repair-estimates'); ?></h2>
+            <ul class="arm-stats">
+                <li><?php esc_html_e('Total', 'arm-repair-estimates'); ?>: <?php echo esc_html((int) $invoices['total']); ?></li>
+                <li><?php esc_html_e('Paid', 'arm-repair-estimates'); ?>: <?php echo esc_html((int) $invoices['paid']); ?></li>
+                <li><?php esc_html_e('Unpaid', 'arm-repair-estimates'); ?>: <?php echo esc_html((int) $invoices['unpaid']); ?></li>
+                <li><?php esc_html_e('Voided', 'arm-repair-estimates'); ?>: <?php echo esc_html((int) $invoices['void']); ?></li>
+                <li><?php esc_html_e('Average Paid Invoice', 'arm-repair-estimates'); ?>: <?php echo esc_html(number_format_i18n((float) $invoices['avg_paid'], 2)); ?></li>
+                <li><?php esc_html_e('Total Paid', 'arm-repair-estimates'); ?>: <?php echo esc_html(number_format_i18n((float) $invoices['sum_paid'], 2)); ?></li>
+                <li><?php esc_html_e('Total Unpaid', 'arm-repair-estimates'); ?>: <?php echo esc_html(number_format_i18n((float) $invoices['sum_unpaid'], 2)); ?></li>
+                <li><?php esc_html_e('Total Sales Tax', 'arm-repair-estimates'); ?>: <?php echo esc_html(number_format_i18n((float) $invoices['sum_tax'], 2)); ?></li>
+            </ul>
+
+            <h2><?php esc_html_e('Inventory', 'arm-repair-estimates'); ?></h2>
+            <ul class="arm-stats">
+                <li><?php esc_html_e('On-Hand Inventory Value', 'arm-repair-estimates'); ?>: <?php echo esc_html($inventory['exists'] ? $currencyValue : __('N/A', 'arm-repair-estimates')); ?></li>
+            </ul>
+
+            <h2><?php esc_html_e('Warranty Claims', 'arm-repair-estimates'); ?></h2>
+            <ul class="arm-stats">
+                <li><?php esc_html_e('Open', 'arm-repair-estimates'); ?>: <?php echo esc_html((int) $warranty['open']); ?></li>
+                <li><?php esc_html_e('Resolved', 'arm-repair-estimates'); ?>: <?php echo esc_html((int) $warranty['resolved']); ?></li>
+            </ul>
+
+            <h2><?php esc_html_e('SMS Communications', 'arm-repair-estimates'); ?></h2>
+            <ul class="arm-stats">
+                <?php if ($sms['channels']) : ?>
+                    <?php foreach ($sms['channels'] as $channel => $counts) : ?>
+                        <li>
+                            <strong><?php echo esc_html($channel); ?></strong>:
+                            <?php printf(
+                                /* translators: 1: sent count, 2: delivered count, 3: failed count */
+                                esc_html__('Sent %1$s / Delivered %2$s / Failed %3$s', 'arm-repair-estimates'),
+                                esc_html((int) $counts['sent']),
+                                esc_html((int) $counts['delivered']),
+                                esc_html((int) $counts['failed'])
+                            ); ?>
+                        </li>
+                    <?php endforeach; ?>
+                <?php else : ?>
+                    <li><?php esc_html_e('No SMS activity recorded yet.', 'arm-repair-estimates'); ?></li>
+                <?php endif; ?>
+            </ul>
+
+            <h2><?php esc_html_e('Trends', 'arm-repair-estimates'); ?></h2>
+            <div style="max-width:800px;">
+                <canvas id="arm_invoice_chart"></canvas>
+            </div>
+            <div style="max-width:800px;margin-top:2em;">
+                <canvas id="arm_estimate_chart"></canvas>
+            </div>
+            <?php if ($sms['channels']) : ?>
+                <div style="max-width:800px;margin-top:2em;">
+                    <canvas id="arm_sms_chart"></canvas>
+                </div>
+            <?php endif; ?>
+
+            <h2><?php esc_html_e('Quick Links', 'arm-repair-estimates'); ?></h2>
+            <p>
+                <a class="button" href="<?php echo esc_url(admin_url('admin.php?page=arm-dashboard')); ?>"><?php esc_html_e('Dashboard', 'arm-repair-estimates'); ?></a>
+                <a class="button" href="<?php echo esc_url(admin_url('admin.php?page=arm-appointments')); ?>"><?php esc_html_e('Appointments', 'arm-repair-estimates'); ?></a>
+                <a class="button" href="<?php echo esc_url(admin_url('admin.php?page=arm-repair-estimates')); ?>"><?php esc_html_e('Estimates', 'arm-repair-estimates'); ?></a>
+                <a class="button" href="<?php echo esc_url(admin_url('admin.php?page=arm-repair-invoices')); ?>"><?php esc_html_e('Invoices', 'arm-repair-estimates'); ?></a>
+            </p>
         </div>
+        <script>
+        document.addEventListener('DOMContentLoaded', function(){
+            const invoiceCtx = document.getElementById('arm_invoice_chart');
+            if (invoiceCtx) {
+                new Chart(invoiceCtx.getContext('2d'), {
+                    type: 'bar',
+                    data: {
+                        labels: <?php echo wp_json_encode($invoiceSeries['labels']); ?>,
+                        datasets: [{
+                            label: '<?php echo esc_js(__('Invoice Totals', 'arm-repair-estimates')); ?>',
+                            data: <?php echo wp_json_encode($invoiceSeries['totals']); ?>,
+                            backgroundColor: 'rgba(75, 192, 192, 0.6)'
+                        }]
+                    },
+                    options: {scales: {y: {beginAtZero: true}}}
+                });
+            }
+
+            const estimateCtx = document.getElementById('arm_estimate_chart');
+            if (estimateCtx) {
+                new Chart(estimateCtx.getContext('2d'), {
+                    type: 'line',
+                    data: {
+                        labels: <?php echo wp_json_encode($estimateSeries['labels']); ?>,
+                        datasets: [
+                            {
+                                label: '<?php echo esc_js(__('Approved', 'arm-repair-estimates')); ?>',
+                                data: <?php echo wp_json_encode($estimateSeries['approved']); ?>,
+                                borderColor: 'rgba(54, 162, 235, 1)',
+                                fill: false
+                            },
+                            {
+                                label: '<?php echo esc_js(__('Rejected', 'arm-repair-estimates')); ?>',
+                                data: <?php echo wp_json_encode($estimateSeries['rejected']); ?>,
+                                borderColor: 'rgba(255, 99, 132, 1)',
+                                fill: false
+                            }
+                        ]
+                    },
+                    options: {scales: {y: {beginAtZero: true}}}
+                });
+            }
+
+            const smsCtx = document.getElementById('arm_sms_chart');
+            if (smsCtx) {
+                new Chart(smsCtx.getContext('2d'), {
+                    type: 'bar',
+                    data: {
+                        labels: <?php echo wp_json_encode($smsLabels); ?>,
+                        datasets: [
+                            {
+                                label: '<?php echo esc_js(__('Sent', 'arm-repair-estimates')); ?>',
+                                data: <?php echo wp_json_encode($smsSent); ?>,
+                                backgroundColor: 'rgba(54, 162, 235, 0.5)'
+                            },
+                            {
+                                label: '<?php echo esc_js(__('Delivered', 'arm-repair-estimates')); ?>',
+                                data: <?php echo wp_json_encode($smsDelivered); ?>,
+                                backgroundColor: 'rgba(75, 192, 92, 0.5)'
+                            },
+                            {
+                                label: '<?php echo esc_js(__('Failed', 'arm-repair-estimates')); ?>',
+                                data: <?php echo wp_json_encode($smsFailed); ?>,
+                                backgroundColor: 'rgba(255, 99, 132, 0.5)'
+                            }
+                        ]
+                    },
+                    options: {
+                        responsive: true,
+                        scales: {
+                            x: {stacked: true},
+                            y: {beginAtZero: true, stacked: true}
+                        }
+                    }
+                });
+            }
+        });
+        </script>
         <?php
     }
 }

--- a/includes/admin/DashboardMetrics.php
+++ b/includes/admin/DashboardMetrics.php
@@ -1,0 +1,284 @@
+<?php
+namespace ARM\Admin;
+
+use wpdb;
+
+if (!defined('ABSPATH')) exit;
+
+require_once __DIR__ . '/Inventory.php';
+
+/**
+ * Collection of helper queries that power the admin dashboard KPIs.
+ * Each method defends against missing tables and normalises return structures
+ * so they can be asserted in isolation during unit tests.
+ */
+final class DashboardMetrics
+{
+    private const SMS_TABLE_CANDIDATES = [
+        'arm_sms_logs',
+        'arm_sms_log',
+        'arm_twilio_logs',
+        'arm_twilio_log',
+        'arm_message_log',
+    ];
+
+    public static function estimate_counts(wpdb $wpdb): array
+    {
+        $table = $wpdb->prefix . 'arm_estimates';
+        if (!self::table_exists($wpdb, $table)) {
+            return [
+                'exists'   => false,
+                'pending'  => 0,
+                'approved' => 0,
+                'rejected' => 0,
+            ];
+        }
+
+        return [
+            'exists'   => true,
+            'pending'  => (int) $wpdb->get_var("SELECT COUNT(*) FROM $table WHERE status='PENDING'"),
+            'approved' => (int) $wpdb->get_var("SELECT COUNT(*) FROM $table WHERE status='APPROVED'"),
+            'rejected' => (int) $wpdb->get_var("SELECT COUNT(*) FROM $table WHERE status='REJECTED'"),
+        ];
+    }
+
+    public static function invoice_counts(wpdb $wpdb): array
+    {
+        $table = $wpdb->prefix . 'arm_invoices';
+        if (!self::table_exists($wpdb, $table)) {
+            return [
+                'exists'      => false,
+                'total'       => 0,
+                'paid'        => 0,
+                'unpaid'      => 0,
+                'void'        => 0,
+                'avg_paid'    => 0.0,
+                'sum_paid'    => 0.0,
+                'sum_unpaid'  => 0.0,
+                'sum_tax'     => 0.0,
+            ];
+        }
+
+        return [
+            'exists'      => true,
+            'total'       => (int) $wpdb->get_var("SELECT COUNT(*) FROM $table"),
+            'paid'        => (int) $wpdb->get_var("SELECT COUNT(*) FROM $table WHERE status='PAID'"),
+            'unpaid'      => (int) $wpdb->get_var("SELECT COUNT(*) FROM $table WHERE status='UNPAID'"),
+            'void'        => (int) $wpdb->get_var("SELECT COUNT(*) FROM $table WHERE status='VOID'"),
+            'avg_paid'    => (float) $wpdb->get_var("SELECT AVG(total) FROM $table WHERE status='PAID'"),
+            'sum_paid'    => (float) $wpdb->get_var("SELECT SUM(total) FROM $table WHERE status='PAID'"),
+            'sum_unpaid'  => (float) $wpdb->get_var("SELECT SUM(total) FROM $table WHERE status='UNPAID'"),
+            'sum_tax'     => (float) $wpdb->get_var("SELECT SUM(tax_amount) FROM $table WHERE status='PAID'"),
+        ];
+    }
+
+    public static function invoice_monthly_totals(wpdb $wpdb, int $months = 6): array
+    {
+        $table = $wpdb->prefix . 'arm_invoices';
+        if (!self::table_exists($wpdb, $table)) {
+            return [
+                'labels' => [],
+                'totals' => [],
+            ];
+        }
+
+        $sql = $wpdb->prepare(
+            "SELECT DATE_FORMAT(created_at,'%%Y-%%m') AS ym, SUM(total) AS total
+             FROM $table WHERE status='PAID'
+             GROUP BY ym ORDER BY ym DESC LIMIT %d",
+            max(1, $months)
+        );
+
+        $rows   = $wpdb->get_results($sql);
+        $labels = [];
+        $totals = [];
+        foreach (array_reverse($rows ?: []) as $row) {
+            $labels[] = (string) $row->ym;
+            $totals[] = (float) $row->total;
+        }
+
+        return compact('labels', 'totals');
+    }
+
+    public static function estimate_trends(wpdb $wpdb, int $months = 6): array
+    {
+        $table = $wpdb->prefix . 'arm_estimates';
+        if (!self::table_exists($wpdb, $table)) {
+            return [
+                'labels'   => [],
+                'approved' => [],
+                'rejected' => [],
+            ];
+        }
+
+        $sql = $wpdb->prepare(
+            "SELECT DATE_FORMAT(created_at,'%%Y-%%m') AS ym,
+                    SUM(CASE WHEN status='APPROVED' THEN 1 ELSE 0 END) AS approved,
+                    SUM(CASE WHEN status='REJECTED' THEN 1 ELSE 0 END) AS rejected
+             FROM $table GROUP BY ym ORDER BY ym DESC LIMIT %d",
+            max(1, $months)
+        );
+
+        $rows     = $wpdb->get_results($sql);
+        $labels   = [];
+        $approved = [];
+        $rejected = [];
+        foreach (array_reverse($rows ?: []) as $row) {
+            $labels[]   = (string) $row->ym;
+            $approved[] = (int) $row->approved;
+            $rejected[] = (int) $row->rejected;
+        }
+
+        return compact('labels', 'approved', 'rejected');
+    }
+
+    public static function inventory_value(wpdb $wpdb): array
+    {
+        $table = $wpdb->prefix . 'arm_inventory';
+        if (!self::table_exists($wpdb, $table)) {
+            return [
+                'exists' => false,
+                'value'  => 0.0,
+            ];
+        }
+
+        $cols = Inventory::schema_columns($table);
+        $qty  = $cols['qty'] ?? 'qty_on_hand';
+        $price = $cols['price'] ?? 'price';
+
+        $sql = "SELECT SUM(COALESCE($qty,0) * COALESCE($price,0)) FROM $table";
+        $value = (float) $wpdb->get_var($sql);
+
+        return [
+            'exists' => true,
+            'value'  => $value,
+        ];
+    }
+
+    public static function warranty_claim_counts(wpdb $wpdb): array
+    {
+        $table = $wpdb->prefix . 'arm_warranty_claims';
+        if (!self::table_exists($wpdb, $table)) {
+            return [
+                'exists'  => false,
+                'open'    => 0,
+                'resolved'=> 0,
+            ];
+        }
+
+        $sql = "SELECT
+                    SUM(CASE WHEN UPPER(status) IN ('RESOLVED','CLOSED') THEN 1 ELSE 0 END) AS resolved,
+                    SUM(CASE WHEN UPPER(status) IN ('RESOLVED','CLOSED') THEN 0 ELSE 1 END) AS open
+                FROM $table";
+        $row = $wpdb->get_row($sql);
+
+        return [
+            'exists'   => true,
+            'open'     => (int) ($row->open ?? 0),
+            'resolved' => (int) ($row->resolved ?? 0),
+        ];
+    }
+
+    public static function sms_totals(wpdb $wpdb): array
+    {
+        $table = self::resolve_sms_table($wpdb);
+        if (!$table) {
+            return [
+                'exists'   => false,
+                'channels' => [],
+            ];
+        }
+
+        $columns = self::column_map($wpdb, $table, [
+            'status'  => ['status', 'delivery_status', 'state'],
+            'channel' => ['channel', 'context', 'category', 'hook'],
+        ]);
+
+        if (empty($columns['status'])) {
+            return [
+                'exists'   => true,
+                'channels' => [],
+            ];
+        }
+
+        $statusCol  = $columns['status'];
+        $channelCol = $columns['channel'];
+
+        if ($channelCol) {
+            $sql = "SELECT COALESCE($channelCol, 'unknown') AS channel,
+                           SUM(CASE WHEN UPPER($statusCol)='SENT' THEN 1 ELSE 0 END) AS sent,
+                           SUM(CASE WHEN UPPER($statusCol)='DELIVERED' THEN 1 ELSE 0 END) AS delivered,
+                           SUM(CASE WHEN UPPER($statusCol)='FAILED' THEN 1 ELSE 0 END) AS failed
+                    FROM $table GROUP BY channel ORDER BY channel";
+            $rows = $wpdb->get_results($sql);
+            $channels = [];
+            foreach ($rows ?: [] as $row) {
+                $label = (string) $row->channel;
+                $channels[$label] = [
+                    'sent'      => (int) $row->sent,
+                    'delivered' => (int) $row->delivered,
+                    'failed'    => (int) $row->failed,
+                ];
+            }
+        } else {
+            $sql = "SELECT
+                        SUM(CASE WHEN UPPER($statusCol)='SENT' THEN 1 ELSE 0 END) AS sent,
+                        SUM(CASE WHEN UPPER($statusCol)='DELIVERED' THEN 1 ELSE 0 END) AS delivered,
+                        SUM(CASE WHEN UPPER($statusCol)='FAILED' THEN 1 ELSE 0 END) AS failed
+                    FROM $table";
+            $row = $wpdb->get_row($sql);
+            $channels = [
+                __('All Channels', 'arm-repair-estimates') => [
+                    'sent'      => (int) ($row->sent ?? 0),
+                    'delivered' => (int) ($row->delivered ?? 0),
+                    'failed'    => (int) ($row->failed ?? 0),
+                ],
+            ];
+        }
+
+        return [
+            'exists'   => true,
+            'channels' => $channels,
+        ];
+    }
+
+    private static function table_exists(wpdb $wpdb, string $table): bool
+    {
+        $like = $wpdb->esc_like($table);
+        return (bool) $wpdb->get_var($wpdb->prepare('SHOW TABLES LIKE %s', $like));
+    }
+
+    private static function resolve_sms_table(wpdb $wpdb): ?string
+    {
+        foreach (self::SMS_TABLE_CANDIDATES as $candidate) {
+            $table = $wpdb->prefix . $candidate;
+            if (self::table_exists($wpdb, $table)) {
+                return $table;
+            }
+        }
+        return null;
+    }
+
+    private static function column_map(wpdb $wpdb, string $table, array $map): array
+    {
+        $cols = $wpdb->get_col(
+            $wpdb->prepare(
+                "SELECT COLUMN_NAME FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = %s",
+                $table
+            )
+        ) ?: [];
+        $lookup = array_change_key_case(array_flip($cols), CASE_LOWER);
+        $picked = [];
+        foreach ($map as $key => $candidates) {
+            $picked[$key] = null;
+            foreach ($candidates as $candidate) {
+                $normalized = strtolower($candidate);
+                if (isset($lookup[$normalized])) {
+                    $picked[$key] = $candidate;
+                    break;
+                }
+            }
+        }
+        return $picked;
+    }
+}

--- a/includes/admin/Inventory.php
+++ b/includes/admin/Inventory.php
@@ -341,6 +341,15 @@ final class Inventory
     }
 
     /**
+     * Public wrapper so other modules (dashboards, exports, tests) can reuse the
+     * schema discovery while still funnelling through a single implementation.
+     */
+    public static function schema_columns(string $table): array
+    {
+        return self::schema_map($table);
+    }
+
+    /**
      * Schema map: resolves commonly used columns.
      * Returns keys: id,name,sku,qty,threshold,cost,price,vendor,notes
      */


### PR DESCRIPTION
## Summary
- refactor the admin dashboard to load metrics via a dedicated helper and display new inventory, warranty, and SMS KPIs alongside existing stats
- add Chart.js visualization for SMS delivery by channel while reworking quick links order per dashboard guidelines
- expose inventory schema discovery for reuse in dashboard queries

## Testing
- php -l includes/admin/Dashboard.php
- php -l includes/admin/DashboardMetrics.php

------
https://chatgpt.com/codex/tasks/task_e_68dc3803c34c832c85324303460ec4de