### PR TITLE
Fix admin assets access to estimate item row template

### DIFF
--- a/includes/estimates/Controller.php
+++ b/includes/estimates/Controller.php
@@ -511,8 +511,13 @@ class Controller {
         </div>';
     }
 
-    /** Single item row render (existing or blank) */
-    private static function render_item_row($jobIndex, $rowIndex, $it) {
+    /**
+     * Tiny raw template used by inline JS to add rows dynamically.
+     *
+     * Public so other components (e.g. admin assets) can reuse the template
+     * without duplicating markup or violating visibility constraints.
+     */
+    public static function item_row_template() {
         $types = ['LABOR'=>'Labor','PART'=>'Part','FEE'=>'Fee','DISCOUNT'=>'Discount'];
         $type = $it->item_type ?? 'LABOR';
         $desc = $it->description ?? '';


### PR DESCRIPTION
## Summary
- expose the estimate item row template so admin assets can reuse it
- document why the template method is public for shared use

## Testing
- php -l includes/estimates/Controller.php

------
https://chatgpt.com/codex/tasks/task_e_68e28e0f2684832cb93a259dc2141bde