### PR TITLE
Add shortlink bootstrapping and activation support

### DIFF
--- a/arm-repair-estimates.php
+++ b/arm-repair-estimates.php
@@ -47,6 +47,8 @@ add_action('plugins_loaded', function () {
     ARM\Invoices\Controller::boot();
     ARM\Invoices\PublicView::boot();
 
+    ARM\Links\Shortlinks::boot();
+
     ARM\Bundles\Controller::boot();
     ARM\Bundles\Ajax::boot();
 

--- a/includes/install/class-activator.php
+++ b/includes/install/class-activator.php
@@ -199,6 +199,11 @@ final class Activator {
         if (class_exists('\\ARM\\Integrations\\Payments_PayPal')) {
             \ARM\Integrations\Payments_PayPal::install_tables();
         }
+        if (class_exists('\\ARM\\Links\\Shortlinks')) {
+            \ARM\Links\Shortlinks::install_tables();
+            \ARM\Links\Shortlinks::add_rewrite_rules();
+            flush_rewrite_rules();
+        }
 
     }
 
@@ -213,6 +218,7 @@ final class Activator {
             '\\ARM\\PDF\\Controller'       => 'includes/pdf/Controller.php',
             '\\ARM\\Integrations\\Payments_Stripe'  => 'includes/integrations/Payments_Stripe.php',
             '\\ARM\\Integrations\\Payments_PayPal'    => 'includes/integrations/Payments_PayPal.php',
+            '\\ARM\\Links\\Shortlinks'      => 'includes/links/class-shortlinks.php',
         ];
         foreach ($map as $class => $rel) {
             if (!class_exists($class) && file_exists(ARM_RE_PATH . $rel)) {


### PR DESCRIPTION
## Summary
- boot the shortlink module when the plugin loads so its hooks register
- require the shortlink module during activation, install its tables, and flush rewrites for new codes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e4a04e66fc832ca81d742262426cfe