### PR TITLE
Fix admin asset enqueue to load estimate builder script

### DIFF
--- a/includes/admin/Assets.php
+++ b/includes/admin/Assets.php
@@ -9,8 +9,8 @@ class Assets {
     public static function enqueue($hook) {
         if (strpos($hook, 'arm-repair') === false) return;
         wp_enqueue_style('arm-re-admin', ARM_RE_URL.'assets/css/arm-frontend.css', [], ARM_RE_VERSION);
-        wp_enqueue_script('arm-estimate-admin', ARM_RE_URL.'assets/js/arm-estimate-admin.js', ['jquery'], ARM_RE_VERSION, true);
-        wp_localize_script('arm-estimate-admin', 'ARM_RE_EST', [
+        wp_enqueue_script('arm-admin', ARM_RE_URL.'assets/js/arm-admin.js', ['jquery'], ARM_RE_VERSION, true);
+        wp_localize_script('arm-admin', 'ARM_RE_EST', [
             'nonce'      => wp_create_nonce('arm_re_est_admin'),
             'ajax_url'   => admin_url('admin-ajax.php'),
             'rest'       => [


### PR DESCRIPTION
## Summary
- update the admin asset registration to load the existing arm-admin.js bundle
- align the localization call to the new script handle so estimate builder helpers receive data

## Testing
- not run (environment not configured for WordPress admin)

------
https://chatgpt.com/codex/tasks/task_e_68e5398cd8bc832c9f8dd50bc6194d7e