### PR TITLE
Ensure customer AJAX search validates nonce

### DIFF
--- a/includes/admin/Customers.php
+++ b/includes/admin/Customers.php
@@ -429,8 +429,10 @@ final class Customers {
 
     /** ===== AJAX search for customers (admin use & estimate builder search) ===== */
     public static function ajax_search(): void {
+        \check_ajax_referer('arm_re_est_admin', 'nonce');
+
         if (!\current_user_can('manage_options')) \wp_send_json_error();
-        $term = isset($_GET['q']) ? \sanitize_text_field($_GET['q']) : '';
+        $term = isset($_REQUEST['q']) ? \sanitize_text_field($_REQUEST['q']) : '';
         global $wpdb;
         $tbl = $wpdb->prefix . 'arm_customers';
 


### PR DESCRIPTION
## Summary
- validate the admin customer search AJAX endpoint with the arm_re_est_admin nonce
- accept search terms from either GET or POST requests while preserving sanitization and capability checks

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e53e8391a4832c86bec8e5dac686a0