### PR TITLE
Fix appointments schema activation and upgrade

### DIFF
--- a/arm-repair-estimates.php
+++ b/arm-repair-estimates.php
@@ -17,6 +17,9 @@ require_once ARM_RE_PATH . 'includes/install/class-activator.php';
 register_activation_hook(__FILE__, ['ARM\\Install\\Activator', 'activate']);
 register_uninstall_hook(__FILE__,  ['ARM\\Install\\Activator', 'uninstall']);
 
+// Run upgrades early so dependent modules operate on the latest schema.
+add_action('plugins_loaded', ['ARM\\Install\\Activator', 'maybe_upgrade'], 1);
+
 
 // Boot in phases (admin vs public)
 add_action('plugins_loaded', function () {


### PR DESCRIPTION
## Summary
- stop the plugin activator from recreating the legacy appointments schema and rely on the module installer
- add a migration routine that renames legacy start/end columns and recreates supporting indexes without data loss
- run the upgrade hook during plugin bootstrap so queries always see the updated datetime fields

## Testing
- php -l includes/install/class-activator.php
- php -l includes/appointments/Installer.php
- php -l arm-repair-estimates.php

------
https://chatgpt.com/codex/tasks/task_e_68e541915c58832c8b8cf761c8da56e2