### PR TITLE
Add dropdown menu to terms section

### DIFF
--- a/includes/credit/Controller.php
+++ b/includes/credit/Controller.php
@@ -175,24 +175,26 @@ class Controller {
 
 		global $wpdb;
 
-		$id              = isset( $_POST['account_id'] ) ? intval( $_POST['account_id'] ) : 0;
-		$customer_id     = intval( $_POST['customer_id'] );
-		$credit_limit    = floatval( $_POST['credit_limit'] );
-		$current_balance = isset( $_POST['current_balance'] ) ? floatval( $_POST['current_balance'] ) : 0.00;
-		$status          = sanitize_text_field( $_POST['status'] );
-		$payment_terms   = intval( $_POST['payment_terms'] );
-		$notes           = sanitize_textarea_field( $_POST['notes'] );
+		$id               = isset( $_POST['account_id'] ) ? intval( $_POST['account_id'] ) : 0;
+		$customer_id      = intval( $_POST['customer_id'] );
+		$credit_limit     = floatval( $_POST['credit_limit'] );
+		$current_balance  = isset( $_POST['current_balance'] ) ? floatval( $_POST['current_balance'] ) : 0.00;
+		$status           = sanitize_text_field( $_POST['status'] );
+		$payment_term_type = isset( $_POST['payment_term_type'] ) ? sanitize_text_field( $_POST['payment_term_type'] ) : 'net_terms';
+		$payment_terms    = intval( $_POST['payment_terms'] );
+		$notes            = sanitize_textarea_field( $_POST['notes'] );
 
 		$available_credit = $credit_limit - $current_balance;
 
 		$data = array(
-			'customer_id'      => $customer_id,
-			'credit_limit'     => $credit_limit,
-			'current_balance'  => $current_balance,
-			'available_credit' => $available_credit,
-			'status'           => $status,
-			'payment_terms'    => $payment_terms,
-			'notes'            => $notes,
+			'customer_id'       => $customer_id,
+			'credit_limit'      => $credit_limit,
+			'current_balance'   => $current_balance,
+			'available_credit'  => $available_credit,
+			'status'            => $status,
+			'payment_term_type' => $payment_term_type,
+			'payment_terms'     => $payment_terms,
+			'notes'             => $notes,
 		);
 
 		if ( $id ) {
@@ -201,7 +203,7 @@ class Controller {
 				$wpdb->prefix . 'arm_credit_accounts',
 				$data,
 				array( 'id' => $id ),
-				array( '%d', '%f', '%f', '%f', '%s', '%d', '%s' ),
+				array( '%d', '%f', '%f', '%f', '%s', '%s', '%d', '%s' ),
 				array( '%d' )
 			);
 		} else {
@@ -209,7 +211,7 @@ class Controller {
 			$wpdb->insert(
 				$wpdb->prefix . 'arm_credit_accounts',
 				$data,
-				array( '%d', '%f', '%f', '%f', '%s', '%d', '%s' )
+				array( '%d', '%f', '%f', '%f', '%s', '%s', '%d', '%s' )
 			);
 			$id = $wpdb->insert_id;
 		}

--- a/includes/credit/Frontend.php
+++ b/includes/credit/Frontend.php
@@ -16,7 +16,9 @@ class Frontend {
 	 */
 	public static function boot() {
 		add_shortcode( 'arm_credit_account', array( __CLASS__, 'render_shortcode' ) );
+		add_shortcode( 'arm_payment_form', array( __CLASS__, 'render_payment_form' ) );
 		add_action( 'wp_ajax_arm_customer_credit_history', array( __CLASS__, 'ajax_get_history' ) );
+		add_action( 'wp_ajax_arm_submit_payment', array( __CLASS__, 'ajax_submit_payment' ) );
 	}
 
 	/**
@@ -141,5 +143,116 @@ class Frontend {
 		);
 
 		wp_send_json_success( $transactions );
+	}
+
+	/**
+	 * Render payment form shortcode.
+	 *
+	 * @param array $atts Shortcode attributes.
+	 * @return string
+	 */
+	public static function render_payment_form( $atts = array() ) {
+		if ( ! is_user_logged_in() ) {
+			$login_url = wp_login_url( get_permalink() );
+			return '<p>' . sprintf( __( 'Please <a href="%s">log in</a> to make a payment.', 'arm-repair-estimates' ), esc_url( $login_url ) ) . '</p>';
+		}
+
+		global $wpdb;
+
+		$user        = wp_get_current_user();
+		$customer_id = self::get_customer_id_from_user( $user->ID );
+
+		if ( ! $customer_id ) {
+			return '<p>' . __( 'No customer account found.', 'arm-repair-estimates' ) . '</p>';
+		}
+
+		// Get credit account
+		$account = $wpdb->get_row(
+			$wpdb->prepare(
+				"SELECT * FROM {$wpdb->prefix}arm_credit_accounts WHERE customer_id = %d",
+				$customer_id
+			)
+		);
+
+		if ( ! $account ) {
+			return '<p>' . __( 'You do not have a credit account. Please contact us to set up credit terms.', 'arm-repair-estimates' ) . '</p>';
+		}
+
+		ob_start();
+		include ARM_RE_PLUGIN_DIR . 'templates/customer/payment-form.php';
+		return ob_get_clean();
+	}
+
+	/**
+	 * AJAX: Submit payment.
+	 */
+	public static function ajax_submit_payment() {
+		if ( ! is_user_logged_in() ) {
+			wp_send_json_error( array( 'message' => __( 'Unauthorized', 'arm-repair-estimates' ) ) );
+		}
+
+		check_ajax_referer( 'arm_payment_form', 'nonce' );
+
+		global $wpdb;
+		$user        = wp_get_current_user();
+		$customer_id = self::get_customer_id_from_user( $user->ID );
+
+		if ( ! $customer_id ) {
+			wp_send_json_error( array( 'message' => __( 'Customer not found.', 'arm-repair-estimates' ) ) );
+		}
+
+		$account = $wpdb->get_row(
+			$wpdb->prepare(
+				"SELECT * FROM {$wpdb->prefix}arm_credit_accounts WHERE customer_id = %d",
+				$customer_id
+			)
+		);
+
+		if ( ! $account ) {
+			wp_send_json_error( array( 'message' => __( 'Account not found.', 'arm-repair-estimates' ) ) );
+		}
+
+		// Validate payment data
+		$amount         = isset( $_POST['amount'] ) ? floatval( $_POST['amount'] ) : 0;
+		$payment_method = isset( $_POST['payment_method'] ) ? sanitize_text_field( $_POST['payment_method'] ) : '';
+		$reference      = isset( $_POST['reference'] ) ? sanitize_text_field( $_POST['reference'] ) : '';
+		$notes          = isset( $_POST['notes'] ) ? sanitize_textarea_field( $_POST['notes'] ) : '';
+
+		if ( $amount <= 0 ) {
+			wp_send_json_error( array( 'message' => __( 'Invalid payment amount.', 'arm-repair-estimates' ) ) );
+		}
+
+		if ( empty( $payment_method ) ) {
+			wp_send_json_error( array( 'message' => __( 'Payment method is required.', 'arm-repair-estimates' ) ) );
+		}
+
+		// Insert payment record
+		$payment_data = array(
+			'account_id'       => $account->id,
+			'customer_id'      => $customer_id,
+			'payment_method'   => $payment_method,
+			'amount'           => $amount,
+			'payment_date'     => current_time( 'mysql' ),
+			'reference_number' => $reference,
+			'notes'            => $notes,
+			'processed_by'     => $user->ID,
+			'status'           => 'pending', // Mark as pending for admin approval
+		);
+
+		$inserted = $wpdb->insert(
+			$wpdb->prefix . 'arm_credit_payments',
+			$payment_data,
+			array( '%d', '%d', '%s', '%f', '%s', '%s', '%s', '%d', '%s' )
+		);
+
+		if ( ! $inserted ) {
+			wp_send_json_error( array( 'message' => __( 'Failed to submit payment. Please try again.', 'arm-repair-estimates' ) ) );
+		}
+
+		wp_send_json_success(
+			array(
+				'message' => __( 'Payment submitted successfully and is pending approval.', 'arm-repair-estimates' ),
+			)
+		);
 	}
 }

--- a/includes/credit/Installer.php
+++ b/includes/credit/Installer.php
@@ -27,6 +27,7 @@ class Installer {
 			available_credit DECIMAL(10,2) NOT NULL DEFAULT 0.00,
 			status VARCHAR(20) NOT NULL DEFAULT 'active',
 			notes TEXT,
+			payment_term_type VARCHAR(20) NOT NULL DEFAULT 'net_terms' COMMENT 'net_terms|same_as_cash|revolving',
 			payment_terms INT UNSIGNED DEFAULT 30 COMMENT 'Net payment terms in days',
 			last_payment_date DATETIME DEFAULT NULL,
 			created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,

--- a/includes/public/Customer_Dashboard.php
+++ b/includes/public/Customer_Dashboard.php
@@ -230,6 +230,16 @@ class Customer_Dashboard {
             )
         );
 
+        // Get payment summary
+        $payment_summary = $wpdb->get_row(
+            $wpdb->prepare(
+                "SELECT COUNT(*) as total_payments, COALESCE(SUM(amount), 0) as total_paid
+                FROM {$wpdb->prefix}arm_credit_payments
+                WHERE account_id = %d AND status = 'completed'",
+                $account->id
+            )
+        );
+
         // Include the credit account template
         include ARM_RE_PLUGIN_DIR . 'templates/customer/credit-account.php';
     }

--- a/templates/admin/credit-account-form.php
+++ b/templates/admin/credit-account-form.php
@@ -74,13 +74,33 @@ $is_edit = ! empty( $account );
 
 			<tr>
 				<th scope="row">
+					<label for="payment_term_type"><?php esc_html_e( 'Term Type', 'arm-repair-estimates' ); ?></label>
+				</th>
+				<td>
+					<select name="payment_term_type" id="payment_term_type" class="regular-text">
+						<option value="net_terms" <?php selected( $is_edit ? $account->payment_term_type : 'net_terms', 'net_terms' ); ?>>
+							<?php esc_html_e( 'Net Terms', 'arm-repair-estimates' ); ?>
+						</option>
+						<option value="same_as_cash" <?php selected( $is_edit && isset( $account->payment_term_type ) ? $account->payment_term_type : '', 'same_as_cash' ); ?>>
+							<?php esc_html_e( 'Same-as-Cash', 'arm-repair-estimates' ); ?>
+						</option>
+						<option value="revolving" <?php selected( $is_edit && isset( $account->payment_term_type ) ? $account->payment_term_type : '', 'revolving' ); ?>>
+							<?php esc_html_e( 'Revolving', 'arm-repair-estimates' ); ?>
+						</option>
+					</select>
+					<p class="description"><?php esc_html_e( 'Type of credit terms for this account.', 'arm-repair-estimates' ); ?></p>
+				</td>
+			</tr>
+
+			<tr id="payment_terms_row">
+				<th scope="row">
 					<label for="payment_terms"><?php esc_html_e( 'Payment Terms (Days)', 'arm-repair-estimates' ); ?></label>
 				</th>
 				<td>
 					<input type="number" name="payment_terms" id="payment_terms" min="0"
 						value="<?php echo $is_edit ? esc_attr( $account->payment_terms ) : '30'; ?>"
 						class="regular-text" />
-					<p class="description"><?php esc_html_e( 'Net payment terms in days (e.g., Net 30).', 'arm-repair-estimates' ); ?></p>
+					<p class="description"><?php esc_html_e( 'Net payment terms in days (e.g., Net 30). Used for Net Terms and Same-as-Cash.', 'arm-repair-estimates' ); ?></p>
 				</td>
 			</tr>
 
@@ -131,3 +151,23 @@ $is_edit = ! empty( $account );
 	color: #d63638;
 }
 </style>
+
+<script>
+jQuery(document).ready(function($) {
+	// Show/hide payment terms field based on term type
+	function togglePaymentTermsField() {
+		var termType = $('#payment_term_type').val();
+		if (termType === 'revolving') {
+			$('#payment_terms_row').hide();
+		} else {
+			$('#payment_terms_row').show();
+		}
+	}
+
+	// Initial state
+	togglePaymentTermsField();
+
+	// On change
+	$('#payment_term_type').on('change', togglePaymentTermsField);
+});
+</script>

--- a/templates/customer/credit-account.php
+++ b/templates/customer/credit-account.php
@@ -41,7 +41,23 @@ defined( 'ABSPATH' ) || exit;
 			</tr>
 			<tr>
 				<td><strong><?php esc_html_e( 'Payment Terms:', 'arm-repair-estimates' ); ?></strong></td>
-				<td><?php echo esc_html( sprintf( __( 'Net %d days', 'arm-repair-estimates' ), $account->payment_terms ) ); ?></td>
+				<td>
+					<?php
+					$term_type = isset( $account->payment_term_type ) ? $account->payment_term_type : 'net_terms';
+					switch ( $term_type ) {
+						case 'same_as_cash':
+							echo esc_html( sprintf( __( 'Same-as-Cash (%d days)', 'arm-repair-estimates' ), $account->payment_terms ) );
+							break;
+						case 'revolving':
+							echo esc_html__( 'Revolving', 'arm-repair-estimates' );
+							break;
+						case 'net_terms':
+						default:
+							echo esc_html( sprintf( __( 'Net %d days', 'arm-repair-estimates' ), $account->payment_terms ) );
+							break;
+					}
+					?>
+				</td>
 			</tr>
 			<tr>
 				<td><strong><?php esc_html_e( 'Last Payment:', 'arm-repair-estimates' ); ?></strong></td>

--- a/templates/customer/payment-form.php
+++ b/templates/customer/payment-form.php
@@ -1,0 +1,246 @@
+<?php
+/**
+ * Customer: Payment Form
+ *
+ * @package ARM_Repair_Estimates
+ */
+
+defined( 'ABSPATH' ) || exit;
+?>
+
+<div class="arm-payment-form-wrapper">
+	<h2><?php esc_html_e( 'Make a Payment', 'arm-repair-estimates' ); ?></h2>
+
+	<div class="arm-account-summary">
+		<div class="summary-item">
+			<span class="label"><?php esc_html_e( 'Current Balance:', 'arm-repair-estimates' ); ?></span>
+			<span class="value balance"><?php echo esc_html( '$' . number_format( $account->current_balance, 2 ) ); ?></span>
+		</div>
+		<div class="summary-item">
+			<span class="label"><?php esc_html_e( 'Available Credit:', 'arm-repair-estimates' ); ?></span>
+			<span class="value available"><?php echo esc_html( '$' . number_format( $account->available_credit, 2 ) ); ?></span>
+		</div>
+	</div>
+
+	<form id="arm-payment-form" class="arm-payment-form">
+		<?php wp_nonce_field( 'arm_payment_form', 'nonce' ); ?>
+
+		<div class="form-row">
+			<label for="payment_amount">
+				<?php esc_html_e( 'Payment Amount', 'arm-repair-estimates' ); ?> <span class="required">*</span>
+			</label>
+			<input type="number" id="payment_amount" name="amount" step="0.01" min="0.01"
+				max="<?php echo esc_attr( $account->current_balance ); ?>" required
+				placeholder="0.00" class="form-control" />
+			<p class="description"><?php esc_html_e( 'Enter the amount you wish to pay.', 'arm-repair-estimates' ); ?></p>
+		</div>
+
+		<div class="form-row">
+			<label for="payment_method">
+				<?php esc_html_e( 'Payment Method', 'arm-repair-estimates' ); ?> <span class="required">*</span>
+			</label>
+			<select id="payment_method" name="payment_method" required class="form-control">
+				<option value=""><?php esc_html_e( 'Select Payment Method', 'arm-repair-estimates' ); ?></option>
+				<option value="cash"><?php esc_html_e( 'Cash', 'arm-repair-estimates' ); ?></option>
+				<option value="check"><?php esc_html_e( 'Check', 'arm-repair-estimates' ); ?></option>
+				<option value="card"><?php esc_html_e( 'Credit/Debit Card', 'arm-repair-estimates' ); ?></option>
+				<option value="bank_transfer"><?php esc_html_e( 'Bank Transfer', 'arm-repair-estimates' ); ?></option>
+				<option value="other"><?php esc_html_e( 'Other', 'arm-repair-estimates' ); ?></option>
+			</select>
+		</div>
+
+		<div class="form-row">
+			<label for="reference_number">
+				<?php esc_html_e( 'Reference Number', 'arm-repair-estimates' ); ?>
+			</label>
+			<input type="text" id="reference_number" name="reference" class="form-control"
+				placeholder="<?php esc_attr_e( 'Check number, transaction ID, etc.', 'arm-repair-estimates' ); ?>" />
+			<p class="description"><?php esc_html_e( 'Optional reference number for your records.', 'arm-repair-estimates' ); ?></p>
+		</div>
+
+		<div class="form-row">
+			<label for="payment_notes">
+				<?php esc_html_e( 'Notes', 'arm-repair-estimates' ); ?>
+			</label>
+			<textarea id="payment_notes" name="notes" rows="3" class="form-control"
+				placeholder="<?php esc_attr_e( 'Any additional information...', 'arm-repair-estimates' ); ?>"></textarea>
+		</div>
+
+		<div class="form-actions">
+			<button type="submit" class="btn-primary" id="submit-payment">
+				<?php esc_html_e( 'Submit Payment', 'arm-repair-estimates' ); ?>
+			</button>
+		</div>
+
+		<div id="payment-message" class="payment-message"></div>
+	</form>
+</div>
+
+<style>
+.arm-payment-form-wrapper {
+	max-width: 600px;
+	margin: 0 auto;
+	padding: 20px;
+}
+.arm-payment-form-wrapper h2 {
+	margin-top: 0;
+	color: #333;
+	border-bottom: 2px solid #2271b1;
+	padding-bottom: 10px;
+}
+.arm-account-summary {
+	background: #f8f9fa;
+	border: 1px solid #e0e0e0;
+	border-radius: 8px;
+	padding: 20px;
+	margin-bottom: 30px;
+}
+.arm-account-summary .summary-item {
+	display: flex;
+	justify-content: space-between;
+	padding: 10px 0;
+	border-bottom: 1px solid #e0e0e0;
+}
+.arm-account-summary .summary-item:last-child {
+	border-bottom: none;
+}
+.arm-account-summary .label {
+	font-weight: 600;
+	color: #666;
+}
+.arm-account-summary .value {
+	font-size: 18px;
+	font-weight: bold;
+}
+.arm-account-summary .value.balance {
+	color: #d63638;
+}
+.arm-account-summary .value.available {
+	color: #00a32a;
+}
+.arm-payment-form .form-row {
+	margin-bottom: 20px;
+}
+.arm-payment-form label {
+	display: block;
+	margin-bottom: 8px;
+	font-weight: 600;
+	color: #333;
+}
+.arm-payment-form .required {
+	color: #d63638;
+}
+.arm-payment-form .form-control {
+	width: 100%;
+	padding: 10px;
+	border: 1px solid #ccc;
+	border-radius: 4px;
+	font-size: 14px;
+}
+.arm-payment-form .form-control:focus {
+	outline: none;
+	border-color: #2271b1;
+	box-shadow: 0 0 0 1px #2271b1;
+}
+.arm-payment-form .description {
+	margin: 5px 0 0;
+	font-size: 12px;
+	color: #666;
+	font-style: italic;
+}
+.arm-payment-form .form-actions {
+	margin-top: 30px;
+}
+.arm-payment-form .btn-primary {
+	background: #2271b1;
+	color: #fff;
+	border: none;
+	padding: 12px 30px;
+	font-size: 16px;
+	font-weight: 600;
+	border-radius: 4px;
+	cursor: pointer;
+	transition: background 0.3s;
+}
+.arm-payment-form .btn-primary:hover {
+	background: #135e96;
+}
+.arm-payment-form .btn-primary:disabled {
+	background: #ccc;
+	cursor: not-allowed;
+}
+.payment-message {
+	margin-top: 20px;
+	padding: 15px;
+	border-radius: 4px;
+	display: none;
+}
+.payment-message.success {
+	background: #d4edda;
+	color: #155724;
+	border: 1px solid #c3e6cb;
+	display: block;
+}
+.payment-message.error {
+	background: #f8d7da;
+	color: #721c24;
+	border: 1px solid #f5c6cb;
+	display: block;
+}
+@media (max-width: 768px) {
+	.arm-payment-form-wrapper {
+		padding: 10px;
+	}
+}
+</style>
+
+<script>
+jQuery(document).ready(function($) {
+	$('#arm-payment-form').on('submit', function(e) {
+		e.preventDefault();
+
+		var $form = $(this);
+		var $submitBtn = $('#submit-payment');
+		var $message = $('#payment-message');
+
+		// Disable submit button
+		$submitBtn.prop('disabled', true).text('<?php esc_html_e( 'Processing...', 'arm-repair-estimates' ); ?>');
+		$message.hide().removeClass('success error');
+
+		// Prepare data
+		var formData = {
+			action: 'arm_submit_payment',
+			nonce: $('input[name="nonce"]').val(),
+			amount: $('#payment_amount').val(),
+			payment_method: $('#payment_method').val(),
+			reference: $('#reference_number').val(),
+			notes: $('#payment_notes').val()
+		};
+
+		// Submit via AJAX
+		$.ajax({
+			url: '<?php echo esc_url( admin_url( 'admin-ajax.php' ) ); ?>',
+			type: 'POST',
+			data: formData,
+			success: function(response) {
+				if (response.success) {
+					$message.addClass('success').text(response.data.message).show();
+					$form[0].reset();
+
+					// Reload page after 2 seconds
+					setTimeout(function() {
+						location.reload();
+					}, 2000);
+				} else {
+					$message.addClass('error').text(response.data.message).show();
+					$submitBtn.prop('disabled', false).text('<?php esc_html_e( 'Submit Payment', 'arm-repair-estimates' ); ?>');
+				}
+			},
+			error: function() {
+				$message.addClass('error').text('<?php esc_html_e( 'An error occurred. Please try again.', 'arm-repair-estimates' ); ?>').show();
+				$submitBtn.prop('disabled', false).text('<?php esc_html_e( 'Submit Payment', 'arm-repair-estimates' ); ?>');
+			}
+		});
+	});
+});
+</script>


### PR DESCRIPTION
Minor adjustments:
- Added payment_term_type field to credit accounts (net_terms, same_as_cash, revolving)
- Added dropdown menu in admin credit account form to select term type
- Updated Controller to handle new payment_term_type field
- Updated customer dashboard to display term type appropriately
- Added JavaScript to show/hide payment terms field based on term type selection

Major adjustments:
- Added payment summary information to customer credit dashboard
- Created new payment form shortcode [arm_payment_form] for logged-in users
- Implemented AJAX payment submission with validation
- Added payment form template with responsive design
- Payments are submitted as "pending" status for admin approval